### PR TITLE
Fixed a bug where a schema containing a sub doc cannot be extended.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var mongoose = require('mongoose'),
-    clone = require('clone');
+    owl = require('owl-deepcopy');
 
 var Schema = mongoose.Schema,
     Model = mongoose.Model;
@@ -8,8 +8,9 @@ var Schema = mongoose.Schema,
  * Add a new function to the schema prototype to create a new schema by extending an existing one
  */
 Schema.prototype.extend = function(obj, options) {
+  
   // Deep clone the existing schema so we can add without changing it
-  var newSchema = clone(this);
+  var newSchema = owl.deepCopy(this);
 
   // Fix for callQueue arguments, todo: fix clone implementation
   newSchema.callQueue.forEach(function(k) {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "test": "mocha"
   },
-  "homepage": "https://github.com/briankircho/mongoose-schema-extend",
+  "homepage": "https://github.com/motherinc/mongoose-schema-extend",
   "repository": {
     "type": "git",
-    "url": "git://github.com/briankircho/mongoose-schema-extend.git"
+    "url": "git://github.com/motherinc/mongoose-schema-extend.git"
   },
   "keywords": [
     "mongoose",
@@ -20,8 +20,14 @@
   ],
   "author": "Brian Kirchoff <briankircho@gmail.com>",
   "license": "BSD",
+  "contributors": [ 
+    {
+      "name": "Ajay Sabhaney",
+      "email": "ajay@mothercreative.com"
+    }
+  ],
   "dependencies": {
-    "clone": "~0.1.0",
+    "owl-deepcopy": "~0.0.1",
     "mocha": "~1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
It seems that there was a problem cloning the parent schema. The cloning module owl-deepcopy seems to work fine in place. This addresses issue #2
