### PR TITLE
Don't mess with existing disciminator keys.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,11 @@ Schema.prototype.extend = function(obj, options) {
     newSchema.add(discriminatorField);
 
     // When new documents are saved, include the model name in the discriminatorField
+    // if it is not set already.
     newSchema.pre('save', function(next) {
-      this[key] = this.constructor.modelName;
+      if(this[key] === null || this[key] === undefined) {
+        this[key] = this.constructor.modelName;
+      }
       next();
     });
   }


### PR DESCRIPTION
In certain cases with polymorphic embedded docs, we may want to manually set a discriminator key. In those cases, mongoose-schema-extend should leave it alone.
