### PR TITLE
Changed the model lookup to refect the actual model database.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ Model.prototype.init = function(doc, query, fn) {
 
     // If the discriminatorField contains a model name, we set the documents prototype to that model
     var type = doc[key];
-    var model = mongoose.models[type];
+    var model = this.db.models[type];
     if(model) {
       var newFn = function() {
         // this is pretty ugly, but we need to run the code below before the callback


### PR DESCRIPTION
Mongoosejs supports multiple connections, hence the use of the actual db object in the model structure to lookup the model types. Without this patch, this module is incompatible with mongoose.createConnection().
