### PR TITLE
Fixes a bug when fn is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ Model.prototype.init = function(doc, query, fn) {
       var newFn = function() {
         // this is pretty ugly, but we need to run the code below before the callback
         process.nextTick(function() {
-          fn.apply(this, arguments);
+          if(fn) fn.apply(this, arguments);
         });
       }
       var modelInstance = new model();


### PR DESCRIPTION
In some cases I was getting the following error:

```console
node_modules/mongoose-schema-extend/index.js:67
          fn.apply(this, arguments);
             ^
TypeError: Cannot call method 'apply' of undefined
```

This request fixes the problem.