### PR TITLE
Fixed problem with regexps

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,14 @@ Schema.prototype.extend = function(obj, options) {
     }
     k[1] = args;
   });
+  // Fix validators RegExps
+  Object.keys(this.paths).forEach(function(k) {
+    this.paths[k].validators.forEach(function (validator, index) {
+        if (validator[0] instanceof RegExp) {
+            newSchema.paths[k].validators[index][0] = validator[0];
+        }
+    });
+  }, this);
 
   // Override the existing options with any newly supplied ones
   for(var k in options) {


### PR DESCRIPTION
I've fixed a problem with RegExp in validation.
If you do this.
```js
var mongoose = require('mongoose'),
    extend = require('mongoose-schema-extend');
var Schema = mongoose.Schema;

var PersonSchema = new Schema({
  name : {type: String, validate: /^[a-zA-z ]+$/}
}, { collection : 'users' });

var EmployeeSchema = PersonSchema.extend({
  department : String
});

var Person = mongoose.model('Person', PersonSchema),
    Employee = mongoose.model('Employee', EmployeeSchema);

// Error during validation
var Brian = new Employee({
  name : 'Brian Kirchoff',
  department : 'Engineering'
});
```
It will crash during validation.

I've fixed it.