### PR TITLE
Use grunt for testing, support Regex, support unique fields, add tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var glob = require('glob');
+
+var exclude = ['.git', 'node_modules','bower_components','sample-module'];
+var files = glob.sync("**/test/**/*.js", {});
+
+files = files.filter(function(path) {
+  return exclude.every(function(regexp) {
+    return path.match(regexp) === null;
+  });
+});
+
+/**
+ * Sort a list of paths
+ */
+function pathsort(paths, sep, algorithm) {
+  sep = sep || '/'
+
+  return paths.map(function(el) {
+    return el.split(sep)
+  }).sort(algorithm || levelSorter).map(function(el) {
+    return el.join(sep)
+  })
+}
+
+/**
+ * Level-order sort of a list of paths
+ */
+function levelSorter(a, b) {
+  var l = Math.max(a.length, b.length)
+  for (var i = 0; i < l; i += 1) {
+    if (!(i in a)) return +1
+    if (!(i in b)) return -1
+
+    if (a.length < b.length) return +1
+    if (a.length > b.length) return -1
+  }
+}
+
+files = pathsort(files);
+
+
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+
+    mochaTest: {
+      test: {
+        options: {
+          quiet: false, // Optionally suppress output to standard out (defaults to false)
+          clearRequireCache: true // Optionally clear the require cache before running tests (defaults to false)
+        },
+        src: files
+      }
+    }
+  });
+
+  grunt.registerTask('drop', 'drop the database', function() {
+    var mongoose = require('mongoose');
+
+    // async mode
+    var done = this.async();
+
+    mongoose.connection.once('open', function () {
+      mongoose.connection.db.dropDatabase(function(err) {
+        if(err) {
+          console.log(err);
+        } else {
+          console.log('Successfully dropped db');
+        }
+        mongoose.connection.close(done);
+      });
+    });
+
+    mongoose.connect('mongodb://localhost:27017/mongoose-extend');
+  });
+
+  grunt.loadNpmTasks('grunt-mocha-test');
+
+  grunt.registerTask('test', ['drop', 'mochaTest']);
+};

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-test:
-	@./node_modules/.bin/mocha \
-		--reporter spec
-
-.PHONY: test

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ Model.prototype.init = function(doc, query, fn) {
       var newFn = function() {
         // this is pretty ugly, but we need to run the code below before the callback
         process.nextTick(function() {
-          fn.apply(this, arguments);
+          if(fn && typeof fn === 'function') fn.apply(this, arguments);
         });
       }
       var modelInstance = new model();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "mongoose schema inheritance and discriminator key extension",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "node ./node_modules/.bin/grunt test"
   },
   "homepage": "https://github.com/briankircho/mongoose-schema-extend",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-schema-extend",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "mongoose schema inheritance and discriminator key extension",
   "main": "index.js",
   "scripts": {
@@ -22,15 +22,20 @@
   "contributors": [
     { "name": "Brian Kirchoff", "email": "briankircho@gmail.com" },
     { "name": "Ajay Sabhaney", "email": "ajay@mothercreative.com" },
-    { "name": "Nicholas Calugar", "email" : "njcalugar@gmail.com" }
+    { "name": "Nicholas Calugar", "email" : "njcalugar@gmail.com" },
+    { "name": "Luis Sieira", "email" : "luis.sieira@spacebar.fr" }
   ],
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "owl-deepcopy": "~0.0.1"
   },
   "devDependencies": {
-    "mocha": "~1.3.2",
-    "should": "~1.1.0",
-    "mongoose": "~3.5.7"
+    "glob": "^5.0.15",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-mocha-test": "^0.12.7",
+    "mocha": "^2.3.3",
+    "mongoose": "^4.2.4",
+    "should": "~1.1.0"
   }
 }

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var mongoose = require('mongoose'),
+    extend = require('../../');
+
+var VehicleSchema = mongoose.Schema({
+  year : { type: Number, trim: true }
+}, { collection : 'vehicles', discriminatorKey : '_type' });
+
+var FordSchema = VehicleSchema.extend({
+  year : { type: Number, trim: true, required: true },
+  model: { type: String, trim: true, unique: true, required: true }
+});
+
+var HondaSchema = VehicleSchema.extend({
+  model: { type: String, trim: true, unique: true, required: true }
+});
+
+// This brand allows two different models to be named the same for commertial obscure purposes
+var VeridianDynamicsSchema = VehicleSchema.extend({
+  model: { type: String, trim: true, required: true, unique: false }
+});
+
+var Vehicle = mongoose.model('vehicle2', VehicleSchema),
+  Ford = mongoose.model('ford', FordSchema),
+  Honda = mongoose.model('honda', HondaSchema),
+  VeridianDynamics = mongoose.model('veridianDynamics', VeridianDynamicsSchema);
+
+
+module.exports = {
+  VehicleSchema: VehicleSchema,
+  Vehicle: Vehicle,
+  FordSchema: FordSchema,
+  Ford: Ford,
+  HondaSchema: HondaSchema,
+  Honda: Honda,
+  VeridianDynamicsSchema: VeridianDynamicsSchema,
+  VeridianDynamics: VeridianDynamics
+};

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -1,0 +1,125 @@
+'use strict';
+
+var mongoose = require('mongoose'),
+    should = require('should');
+
+var Schema = mongoose.Schema,
+    fixtures = require('./fixtures');
+
+describe('schema discriminator key tests', function() {
+  beforeEach(function(done) {
+    fixtures.Vehicle.remove({}, function(err) {
+      should.not.exist(err);
+      done();
+    });
+  });
+
+  it('Should allow two different brand vehicles with the same model', function (done) {
+    var fordSierra = new fixtures.Ford({
+      year : 1986,
+      model : 'sierra'
+    });
+
+    var hondaSierra = new fixtures.Honda({
+      year : 2030,
+      model : 'sierra'
+    });
+
+    fordSierra.save(function(err) {
+      should.not.exist(err);
+      fordSierra._type.should.equal('ford');
+
+      hondaSierra.save(function(err) {
+        should.not.exist(err);
+        hondaSierra._type.should.equal('honda');
+        done();
+      })
+    });
+  });
+
+  it('Should not allow two vehicles of the same brand with the same model', function (done) {
+    var fordSierra = new fixtures.Ford({
+      year : 1986,
+      model : 'sierra'
+    });
+
+    var anotherFordSierra = new fixtures.Ford({
+      year : 2030,
+      model : 'sierra'
+    });
+
+    fordSierra.save(function(err) {
+      should.not.exist(err);
+      fordSierra._type.should.equal('ford');
+
+      anotherFordSierra.save(function(err) {
+        should.exist(err);
+        done();
+      })
+    });
+  });
+
+  it('Should allow two vehicles of the same obscure brand with the same model', function (done) {
+    var fordSierra = new fixtures.Ford({
+      year : 1986,
+      model : 'sierra'
+    });
+
+    var veridianDynamics1 = new fixtures.VeridianDynamics({
+      year : 1986,
+      model : 'sierra'
+    });
+
+    var veridianDynamics2 = new fixtures.VeridianDynamics({
+      year : 2030,
+      model : 'sierra'
+    });
+
+    fordSierra.save(function(err) {
+      should.not.exist(err);
+      veridianDynamics1.save(function(err) {
+        should.not.exist(err);
+        veridianDynamics1._type.should.equal('veridianDynamics');
+
+        veridianDynamics2.save(function(err) {
+          should.not.exist(err);
+          veridianDynamics2._type.should.equal('veridianDynamics');
+          done();
+        })
+      });
+    });
+  });
+
+  it('Should not allow to insert objects without a required field', function(done) {
+    var fordSierra = new fixtures.Ford({
+      model : 'sierramorena'
+    });
+
+    fordSierra.save(function(err, data) {
+      should.exist(err);
+      done();
+    });
+  });
+
+  it('Should allow to insert objects without a field that\'s required by a sibling schema', function(done) {
+    var fordSierra = new fixtures.Ford({
+      model : 'sierra'
+    });
+
+    var veridianDynamics1 = new fixtures.VeridianDynamics({
+      model : 'sierra'
+    });
+
+    fordSierra.save(function(err) {
+      should.exist(err);
+      veridianDynamics1.save(function(err) {
+        should.not.exist(err);
+        veridianDynamics1._type.should.equal('veridianDynamics');
+        done();
+      });
+    });
+  });
+
+  //TODO test two children with same attribute names and different validators
+  //TODO test child with regexp
+});


### PR DESCRIPTION
  1- Using grunt to sequentially run all tests
  2- Sepparate fixtures to a common file (only the new ones, it should be done with the former ones)
  3- Fix validator Regexps, as suggested on issue #27
  4- Change the unique fields to compound discriminator/field unique indexes so some sub-schemas can define unique fields other sub-schemas dont require to be unique