### PR TITLE
partially fix middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,20 @@ Schema.prototype.extend = function(obj, options) {
     k[1] = args;
   });
 
+  var that = this;
+
+  // Add new added parent schema hooks to the newSchema
+  Object.observe(that.callQueue, function(changes) {
+    // Hook format in the callQueue is -> [ 'pre', { '0': 'save', '1': [Function] } ]
+    changes.forEach(function(change) {
+      var hookType = change.object[ change.name ][0],
+          eventType = change.object[ change.name ][1]['0'],
+          fn = change.object[ change.name ][1]['1'];
+
+          newSchema[hookType](eventType, fn);
+    });
+  }, ["add"]);
+
   // Fix validators RegExps
   Object.keys(this.paths).forEach(function(k) {
     this.paths[k].validators.forEach(function (validator, index) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "owl-deepcopy": "~0.0.1"
   },
   "devDependencies": {
+    "chai": "^3.4.1",
     "glob": "^5.0.15",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var extend = require('../');
+
+var chai = require('chai').Should(),
+    expect = require('chai').expect;
+
+var fixtures = require('./fixtures');
+
+describe('Hook test', function () {
+  it('All pre middleware should execute', (done) => {
+    var x = false, y = false;
+    var xfirst = false;
+
+    fixtures.VehicleSchema.pre('save', (next) => {
+        x = true;
+        if(!y) { xfirst = true };
+        next();
+    });
+
+    fixtures.VeridianDynamicsSchema.pre('save', (next) => {
+        y = true;
+        next();
+    });
+
+    var veridian = new fixtures.VeridianDynamics({
+      year : 1986,
+      model : 'veridian'
+    });
+
+    veridian.save(() => {
+      x.should.be.true;
+      y.should.be.true;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
While this is working,  the observer doesn't have the time to add the middleware before the save is performed on the test. So i'm not still merging.

The test fails, but all subsequent tests actually run all the middleware as expected, so I need to find a way to force the observer to trigger before any other instruction