### PR TITLE
fix regexp again

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ Schema.prototype.extend = function(obj, options) {
   // Fix validators RegExps
   Object.keys(this.paths).forEach(function(k) {
     this.paths[k].validators.forEach(function (validator, index) {
-        if (validator.validator instanceof RegExp) {
-            newSchema.paths[k].validators[index].validator = validator.validator;
+        if (validator.regexp instanceof RegExp) {
+            newSchema.paths[k].validators[index].regexp = validator.regexp;
         }
     });
   }, this);


### PR DESCRIPTION
Since Version 4.1.0 the regexp are not stored in validator anymore but inside a special regexp property.
I changed the if statement and the assignment accordingly