### PR TITLE
Enable multi-level extend

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ Schema.prototype.extend = function(obj, options) {
       case 'reduce':
         return Array.prototype.reduce.bind(target.concat(that.callQueue));
       default:
-        if(isNaN(property)) {
+        if(typeof property !== 'symbol' && isNaN(property)) {
           return target[property];
         } else {
           return that.callQueue.concat(target)[property];
@@ -45,10 +45,10 @@ Schema.prototype.extend = function(obj, options) {
   Object.keys(this.paths).forEach(function(k) {
     this.paths[k].validators.forEach(function (validator, index) {
         if (validator.validator instanceof RegExp) {
-            newSchema.paths[k].validators[index].validator = validator.validator;
+          newSchema.paths[k].validators[index].validator = validator.validator;
         }
         if (validator.regexp instanceof RegExp) {
- -            newSchema.paths[k].validators[index].regexp = validator.regexp;
+          newSchema.paths[k].validators[index].regexp = validator.regexp;
         }
     });
   }, this);


### PR DESCRIPTION
Test code:

``` js
const mongoose = require('mongoose');
const extend = require('mongoose-schema-extend');
const Schema = mongoose.Schema;

mongoose.connect('mongodb://localhost:27017/test', err => console.error(err));

const UserSchema = new Schema({
  test: String
}, { collection : 'users', discriminatorKey: '__t' });

const PersonSchema = UserSchema.extend({
  name : String
});

const EmployeeSchema = PersonSchema.extend({
  department : String
});

const Person = mongoose.model('person', PersonSchema);
const Employee = mongoose.model('employee', EmployeeSchema);

const James = new Person({
  name: 'James Bond',
});

const Brian = new Employee({
  name : 'Brian Kirchoff',
  department : 'Engineering'
});

Brian.save()
  .then(res => console.log(res))
  .then(() => James.save())
  .then(res => console.log(res));
```
