### PR TITLE
Fixed Schema Inheritance Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,10 @@ Schema.prototype.extend = function(obj, options) {
         return () => target.concat(that.callQueue);
       case 'push':
         return (e) => target.push(e);
-        break;
       case 'reduce':
         return Array.prototype.reduce.bind(target.concat(that.callQueue));
+      case 'unshift':
+        return (e) => target.unshift(e);
       default:
         if (typeof property !== 'symbol' && isNaN(property)) {
           return target[property];


### PR DESCRIPTION
> TypeError: Cannot read property '0' of undefined.
> #56

Fixed the Schema Inheritance Error. Now the signals works ok! I don't know if all it's correct, but I think that's a better solution than hardocode the property to 0.
